### PR TITLE
Add multi-flake devcontainer setup with direnv

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,81 @@
+# Dev Container with Multiple Nix Flakes
+
+This dev container setup allows you to switch between different Nix flakes without restarting the container. It uses direnv with nix-direnv for efficient environment management.
+
+## Setup
+
+The container includes:
+- Nix with flakes support
+- direnv for automatic environment loading
+- nix-direnv for efficient Nix integration with direnv
+- VS Code direnv extension for editor integration
+
+## Usage
+
+### Switching Between Flakes
+
+Use the provided script to switch between different flake environments:
+
+```bash
+./.devcontainer/switch-flake.sh templates/rust
+```
+
+Available flakes in this project:
+- `templates/python`
+- `templates/rust`
+- `templates/go`
+- `templates/kotlin`
+- `templates/nim`
+- `templates/zig`
+
+### After Switching
+
+1. **Terminal**: The environment is automatically reloaded in your current terminal
+2. **VS Code**: Reload the window to pick up the new environment
+   - Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on Mac)
+   - Type "Developer: Reload Window"
+   - Press Enter
+
+## How It Works
+
+1. **`.flake-selection`**: This file stores the currently selected flake path
+2. **`.envrc`**: Reads the selected flake from `.flake-selection` and uses `use flake` to load it
+3. **`switch-flake.sh`**: Updates `.flake-selection` and reloads direnv
+
+The direnv VS Code extension ensures that the editor environment stays in sync with your terminal environment.
+
+## Manual Switching
+
+If you prefer to switch manually:
+
+1. Edit `.flake-selection` to contain the desired flake path (e.g., `templates/rust`)
+2. Run `direnv allow .` to reload the environment
+3. Reload the VS Code window
+
+## Troubleshooting
+
+### Environment not loading
+- Make sure direnv is allowed: `direnv allow .`
+- Check that `.flake-selection` contains a valid path
+- Verify the flake directory has a `flake.nix` file
+
+### VS Code not picking up changes
+- Reload the VS Code window after switching flakes
+- Check that the direnv extension is installed and enabled
+
+### Direnv taking a long time
+- First load of a flake takes time to build/download dependencies
+- Subsequent loads use nix-direnv's cache and are instant
+- The cache is stored in `.direnv/` (ignored by git)
+
+## Configuration
+
+### Adding New Flakes
+
+To add a new flake directory:
+1. Create a directory with a `flake.nix` file
+2. Use the switch script to switch to it: `./.devcontainer/switch-flake.sh path/to/new-flake`
+
+### Customizing the Default
+
+Edit `.flake-selection` to change which flake loads by default when the container starts.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,11 +8,26 @@ echo "Running post-create script..."
 # Install just and curl via Nix
 nix profile install nixpkgs#just nixpkgs#curl
 
-# Allow direnv to load the environment for the workspace
-direnv allow .
+# Install nix-direnv for better Nix integration
+nix profile install nixpkgs#nix-direnv
+
+# Configure nix-direnv
+mkdir -p ~/.config/direnv
+cat > ~/.config/direnv/direnvrc << 'EOF'
+source $HOME/.nix-profile/share/nix-direnv/direnvrc
+EOF
 
 # Add direnv hook to shell configuration files
 echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
 echo 'eval "$(direnv hook bash)"' >> ~/.bashrc
+
+# Create .flake-selection with default if it doesn't exist
+if [ ! -f .flake-selection ]; then
+    echo "templates/python" > .flake-selection
+    echo "Created .flake-selection with default: templates/python"
+fi
+
+# Allow direnv to load the environment for the workspace
+direnv allow .
 
 echo "Post-create script finished."

--- a/.devcontainer/switch-flake.sh
+++ b/.devcontainer/switch-flake.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Script to switch between different Nix flakes in the dev container
+set -e
+
+FLAKE_SELECTION_FILE=".flake-selection"
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 <flake-directory>"
+    echo ""
+    echo "Switch to a different Nix flake environment."
+    echo ""
+    echo "Available flakes:"
+    find templates -maxdepth 1 -type d -not -name templates | sort | sed 's/^/  - /'
+    echo ""
+    echo "Example:"
+    echo "  $0 templates/rust"
+    echo "  $0 templates/python"
+    exit 1
+}
+
+# Check if an argument was provided
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+FLAKE_DIR="$1"
+
+# Validate that the flake directory exists
+if [ ! -d "$FLAKE_DIR" ]; then
+    echo "Error: Directory '$FLAKE_DIR' does not exist"
+    exit 1
+fi
+
+# Validate that the directory contains a flake.nix
+if [ ! -f "$FLAKE_DIR/flake.nix" ]; then
+    echo "Error: No flake.nix found in '$FLAKE_DIR'"
+    exit 1
+fi
+
+# Save the selection
+echo "$FLAKE_DIR" > "$FLAKE_SELECTION_FILE"
+echo "Switched to flake: $FLAKE_DIR"
+
+# Reload direnv
+echo "Reloading direnv environment..."
+direnv allow .
+
+echo ""
+echo "Environment switched successfully!"
+echo ""
+echo "For VS Code to pick up the new environment:"
+echo "  1. Press Ctrl+Shift+P (or Cmd+Shift+P on Mac)"
+echo "  2. Type 'Developer: Reload Window'"
+echo "  3. Press Enter"
+echo ""
+echo "Your terminal environment has been updated."

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,30 @@
-# Placeholder
+#!/usr/bin/env bash
+# This .envrc file reads the selected flake from .flake-selection
+# and loads the environment for that flake using nix-direnv.
+
+FLAKE_SELECTION_FILE=".flake-selection"
+
+# Check if the flake selection file exists
+if [ ! -f "$FLAKE_SELECTION_FILE" ]; then
+    echo "Warning: $FLAKE_SELECTION_FILE not found. Using default (templates/python)"
+    SELECTED_FLAKE="templates/python"
+else
+    # Read the selected flake path from the file
+    SELECTED_FLAKE=$(cat "$FLAKE_SELECTION_FILE" | tr -d '[:space:]')
+fi
+
+# Validate that the selected flake exists
+if [ ! -d "$SELECTED_FLAKE" ]; then
+    echo "Error: Selected flake directory '$SELECTED_FLAKE' does not exist"
+    return 1
+fi
+
+if [ ! -f "$SELECTED_FLAKE/flake.nix" ]; then
+    echo "Error: No flake.nix found in '$SELECTED_FLAKE'"
+    return 1
+fi
+
+echo "Loading environment from flake: $SELECTED_FLAKE"
+
+# Use nix-direnv to load the flake environment
+use flake "./$SELECTED_FLAKE"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Nix
 .direnv/
+.flake-selection
 result
 result-*
 


### PR DESCRIPTION
Implemented a dev container configuration that allows switching between different Nix flakes without restarting the container.

Changes:
- Enhanced post-create.sh to install nix-direnv and configure it
- Updated .envrc to read selected flake from .flake-selection file
- Added switch-flake.sh script for easy flake switching
- Created comprehensive README with usage instructions
- Added .flake-selection to .gitignore for per-user preferences

The setup uses direnv with nix-direnv for efficient environment management. Users can switch between flakes using the switch-flake.sh script, and VS Code will pick up changes after a window reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)