### PR TITLE
Rename s16e01-zig binaries to include language suffix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -175,7 +175,7 @@
                     # Rename main binary if it exists (various names: aoc-template, s16e01, etc.)
                     # First check if binary already has the correct name
                     if [ -f "${prefix}" ] || [ -L "${prefix}" ]; then
-                      # Binary already has correct name (e.g., s16e01-nim), create -main symlink
+                      # Binary already has correct name (e.g., s16e01-nim, s16e01-zig), create -main symlink
                       ln -sf "${prefix}" "${prefix}-main"
                     else
                       # Look for binary with old naming
@@ -186,17 +186,17 @@
                       done
                     fi
                     # Rename part1 and part2 - check both old names and new prefixed names
-                    if [ -f "part1" ] || [ -L "part1" ]; then
+                    if [ -f "${prefix}-part1" ] || [ -L "${prefix}-part1" ]; then
+                      # Binary already has correct name, no additional symlink needed
+                      true
+                    elif [ -f "part1" ] || [ -L "part1" ]; then
                       ln -sf "part1" "${prefix}-part1"
-                    elif [ -f "${prefix}-part1" ] || [ -L "${prefix}-part1" ]; then
-                      # Binary already has correct name, no symlink needed
-                      true
                     fi
-                    if [ -f "part2" ] || [ -L "part2" ]; then
-                      ln -sf "part2" "${prefix}-part2"
-                    elif [ -f "${prefix}-part2" ] || [ -L "${prefix}-part2" ]; then
-                      # Binary already has correct name, no symlink needed
+                    if [ -f "${prefix}-part2" ] || [ -L "${prefix}-part2" ]; then
+                      # Binary already has correct name, no additional symlink needed
                       true
+                    elif [ -f "part2" ] || [ -L "part2" ]; then
+                      ln -sf "part2" "${prefix}-part2"
                     fi
                   fi
                 '';

--- a/src/AoC16/s16e01-zig/flake.nix
+++ b/src/AoC16/s16e01-zig/flake.nix
@@ -29,9 +29,9 @@
             # Set cache dir to avoid read-only filesystem issues
             export XDG_CACHE_HOME=$TMPDIR/zig-cache
 
-            zig build-exe main.zig -O ReleaseSafe -femit-bin=s16e01
-            zig build-exe part1.zig -O ReleaseSafe -femit-bin=part1
-            zig build-exe part2.zig -O ReleaseSafe -femit-bin=part2
+            zig build-exe main.zig -O ReleaseSafe -femit-bin=s16e01-zig
+            zig build-exe part1.zig -O ReleaseSafe -femit-bin=s16e01-zig-part1
+            zig build-exe part2.zig -O ReleaseSafe -femit-bin=s16e01-zig-part2
 
             runHook postBuild
           '';
@@ -40,9 +40,9 @@
             runHook preInstall
 
             mkdir -p $out/bin
-            cp s16e01 $out/bin/
-            cp part1 $out/bin/
-            cp part2 $out/bin/
+            cp s16e01-zig $out/bin/
+            cp s16e01-zig-part1 $out/bin/
+            cp s16e01-zig-part2 $out/bin/
 
             runHook postInstall
           '';
@@ -92,18 +92,18 @@
           # Default: run main verification binary
           default = {
             type = "app";
-            program = "${package}/bin/s16e01";
+            program = "${package}/bin/s16e01-zig";
           };
 
           # Run individual parts
           part1 = {
             type = "app";
-            program = "${package}/bin/part1";
+            program = "${package}/bin/s16e01-zig-part1";
           };
 
           part2 = {
             type = "app";
-            program = "${package}/bin/part2";
+            program = "${package}/bin/s16e01-zig-part2";
           };
         };
 


### PR DESCRIPTION
Updates the Zig compiler output to generate binaries with explicit naming: s16e01-zig, s16e01-zig-part1, and s16e01-zig-part2 instead of the previous s16e01, part1, and part2.

Also updates the root flake wrapper to handle binaries that already have the correct prefix, avoiding redundant symlink creation.